### PR TITLE
Better Handeling of big Reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN cp -r /build/backend/ /app/
 RUN cp -r /build/frontend/dist/ /app/static/
 
 WORKDIR /app
-ENTRYPOINT node dist/index.js
+ENTRYPOINT ["node", "--max-old-space-size=8192", "dist/index.js"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "tsc -p src/",
-    "start": "node dist/index.js",
+    "start": "node --max-old-space-size=8192 dist/index.js",
     "generate-report": "node dist/index.js -generate_report"
   },
   "dependencies": {

--- a/backend/src/database/models/report.ts
+++ b/backend/src/database/models/report.ts
@@ -38,7 +38,7 @@ export const ReportSchema = new Schema({
 }, {
   statics: {
     async addTestRuns(report: IReport & {_id: Types.ObjectId}) {
-      const runs = await DB.TestRun.find({ContainerId: report._id}, "-TestCases").lean().exec();
+      const runs = await DB.TestRun.find({ContainerId: report._id}, "-TestCases -FailureInducingCombinations").lean().exec();
       report.TestRuns = runs;
       return report;
     },

--- a/backend/src/endpoints/UploadReportEndpoint.ts
+++ b/backend/src/endpoints/UploadReportEndpoint.ts
@@ -156,8 +156,8 @@ export namespace UploadReportEndpoint {
           testCase.DisplayName = "";
         }
         let size = Buffer.byteLength(JSON.stringify(testRun));
-        console.log('testRun size (bytes):', size);
         if (size > 16000000) {
+          console.log('testRun size (bytes):', size, "Removing pcap data and FailureInducingCombinations.");
           testRun.FailureInducingCombinations = [];
           testRun.TestCases.forEach((testCase: any) => {
             testCase.PcapData = null;

--- a/backend/src/endpoints/UploadReportEndpoint.ts
+++ b/backend/src/endpoints/UploadReportEndpoint.ts
@@ -134,8 +134,11 @@ export namespace UploadReportEndpoint {
 
     // test runs
     const entries = zipFile.getEntries();
+    let skipCounter = 0;
+    const testRunSavePromises: Promise<any>[] = [];
     for (let entry of entries) {
       if (entry.entryName.endsWith("_testRun.json")) {
+        console.log("parsing: " + entry.entryName);
         let testRun = JSON.parse(entry.getData().toString())
         if ("metadata" in testRun) {
           testRun["MetaData"] = testRun["metadata"];
@@ -149,10 +152,28 @@ export namespace UploadReportEndpoint {
           if (pcapEntry) {
             testCase.PcapData = pcapEntry.getData();
           }
+          // remove displayname as it is redundant information
+          testCase.DisplayName = "";
         }
-        testRun.save()
+        let size = Buffer.byteLength(JSON.stringify(testRun));
+        console.log('testRun size (bytes):', size);
+        if (size > 16000000) {
+          testRun.FailureInducingCombinations = [];
+          testRun.TestCases.forEach((testCase: any) => {
+            testCase.PcapData = null;
+          });
+          if (Buffer.byteLength(JSON.stringify(testRun)) > 16000000) {
+            console.log(" > Too large. Skipped.")
+            skipCounter++;
+            continue;
+          }
+        }
+
+        testRunSavePromises.push(testRun.save());
       }
     }
+    await Promise.all(testRunSavePromises);
+    console.log("Done. Skipped " + skipCounter);
 
     if (res) {
       res.send("OK");

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
 import type { IAnvilJob, IAnvilWorker, IReport, ITestRun } from './lib/data_types';
 
 export module AnvilApi {
-    const baseUrl = import.meta.env.DEV ? "http://localhost:5001/api/v2/" : "/api/v2/";
+    export const baseUrl = import.meta.env.DEV ? "http://localhost:5001/api/v2/" : "/api/v2/";
 
     export function getIdentifiers(): Promise<string[]> {
         return getApiObject("reportIdentifiers");

--- a/frontend/src/components/UploadDialog.vue
+++ b/frontend/src/components/UploadDialog.vue
@@ -78,9 +78,14 @@ export default {
                 this.error = "Error during upload.";
             })
 
+            request.addEventListener('timeout', (e) => {
+                this.uploading = false;
+                this.error = "Timeout reached. The file may still be processing in the background. You can close this window.";
+            })
+
             /** TODO: migrate to $api object in the future? */
-            request.open('post', '/api/v2/uploadReport');
-            request.timeout = 45000;
+            request.open('post', `${this.$api.baseUrl}uploadReport`);
+            request.timeout = 180000;
             request.send(formdata);
         }
     }

--- a/frontend/src/components/UploadDialog.vue
+++ b/frontend/src/components/UploadDialog.vue
@@ -83,7 +83,6 @@ export default {
                 this.error = "Timeout reached. The file may still be processing in the background. You can close this window.";
             })
 
-            /** TODO: migrate to $api object in the future? */
             request.open('post', `${this.$api.baseUrl}uploadReport`);
             request.timeout = 180000;
             request.send(formdata);


### PR DESCRIPTION
Big reports can crash the backend, as the whole extracted zip is loaded into memory. Furthermore big _testRun.json files did not process as MongoDB has a file size limit.
This PR
 - increases the memory Node can use to 8 GB
 - deletes PCAP data and FailureInducingCombinations if they are to big
 - skips testruns entirely if they are to big
 - prints this to the console of the background app